### PR TITLE
Test Fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,12 @@
 
 ## Custom
 .DS_Store
+
+## Test-related (should be fixed)
+dump.bin
+dump.txt
+dump1.txt
+dumpfiltererd.txt
+mdt_msg_samples/hexdump.bin
+models.txt
+pipeline.log

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ BINARY=pipeline
 include skeleton/pipeline.mk
 
 # Setup pretest as a prerequisite of tests.
-test: pretest
-pretest:
-	@echo Setting up zookeeper, kafka. Docker required.
+testall: pretestinfra
+pretestinfra:
+	@echo Setting up Zookeeper and Kafka. Docker required.
 	tools/test/run.sh

--- a/skeleton/pipeline.mk
+++ b/skeleton/pipeline.mk
@@ -38,6 +38,10 @@ bin/$(BINARY): $(SOURCES)
 generated_source:
 	go generate -x
 
+.PHONY: testall
+testall:
+	go test -v -tags=integration -run=. -bench=. $(PROFILE)
+
 .PHONY: test
 test:
 	go test -v -run=. -bench=. $(PROFILE)

--- a/xport_kafka_test.go
+++ b/xport_kafka_test.go
@@ -5,16 +5,18 @@
 // All rights reserved.
 //
 //
+// +build integration
 
 package main
 
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/dlintw/goconf"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/dlintw/goconf"
 )
 
 var kmod kafkaOutputModule


### PR DESCRIPTION
Pull request for tracking #10. Should fix first and last point.

So far simply separates Kafka integration tests and unit tests with `make test` being unit tests only and `make testall` running unit and integration tests. Uncertain if this is reasonable practice.

Simply ignores test output files at the moment via `.gitignore`, somewhat mitigating second point.