### PR TITLE
Cleanup coverage targets in Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,7 @@ dumpfiltererd.txt
 mdt_msg_samples/hexdump.bin
 models.txt
 pipeline.log
+
+# Tests
+
+coverage.out

--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,13 @@ BINARY=pipeline
 
 include skeleton/pipeline.mk
 
+
+# Backward compatibility
+testall: integration-test
+
 # Setup pretest as a prerequisite of tests.
-testall: pretestinfra
+integration-test: pretestinfra
+
 pretestinfra:
 	@echo Setting up Zookeeper and Kafka. Docker required.
 	cd tools/test && ./run.sh

--- a/skeleton/pipeline.mk
+++ b/skeleton/pipeline.mk
@@ -18,9 +18,9 @@ PKG = $(shell go list)
 # source.
 VENDOR = $(PKG)/vendor/
 
-LDFLAGS=-ldflags "-X  main.appVersion=v${VERSION}(bigmuddy)"
+LDFLAGS = -ldflags "-X  main.appVersion=v${VERSION}(bigmuddy)"
 
-SOURCEDIR=.
+SOURCEDIR = .
 SOURCES := $(shell find $(SOURCEDIR) -name '*.go' -o -name "*.proto" )
 # Cumbersome way of excluding vendor directory
 GO_BAR_VENDOR := $(shell go list ./... | egrep -v vendor/)
@@ -34,20 +34,29 @@ bin/$(BINARY): $(SOURCES)
 	go fmt $(GO_BAR_VENDOR)
 	go build $(LDFLAGS) -o bin/$(BINARY)
 
-.PHONY: generated_source
-generated_source:
+.PHONY: generated-source
+generated-source:
 	go generate -x
 
-.PHONY: testall
-testall:
-	go test -v -tags=integration -run=. -bench=. $(PROFILE)
+.PHONY: integration-test
+integration-test:
+	@echo Starting Integration tests
+	go test -v -coverpkg=./... -tags=integration $(COVER_PROFILE) ./...
 
 .PHONY: test
 test:
-	go test -v -run=. -bench=. $(PROFILE)
+	go test -v $(COVER_PROFILE) ./...
 
 .PHONY: coverage
-coverage: PROFILE=-coverprofile=test
+COVER_PROFILE = -coverprofile=coverage.out
 coverage: test
-	go tool cover -html=test
+	go tool cover -html=coverage.out
+
+.PHONY: integration-coverage
+integration-coverage: integration-test
+	go tool cover -html=coverage.out
+
+
+
+
 


### PR DESCRIPTION
Small cleanup

- Change coverage output file from "test" to the traditional more
  meaningful "coverage.out"
- Fix .gitignore accordingly
- Maintain the testall target but called "integration-test" in a sub
  target so that name conveys purpose
- Add "-coverpkg=./... " to integration-test in order to get proper
  numbers
- Simplify "go test" to just use "./..."
- Add integration-coverage target
- In subsequent commits will add "make help"