### PR TITLE
Makefile help

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,5 +31,7 @@ pipeline.log
 .idea/
 
 # Tests
-
 coverage.out
+
+# Binary
+# ./bin

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ BINARY = pipeline
 
 include skeleton/pipeline.mk
 
+## Removes containers, images, binaries and cache
 clean: clean-containers
 	@echo "  >  Cleaning binaries and cache"
 	@-rm -f $(GOBIN)/$(PROJECTNAME)/$(BINARY)
@@ -26,12 +27,51 @@ start-containers: clean-containers
 	@echo "  >  Starting containers"
 	@cd $(DOCKER) && docker-compose up -d
 
-# Backward compatibility
+# Alias for integration-test
 testall: integration-test
 
-# Setup pretest as a prerequisite of tests.
+
+## Integration test with Kafka and Zookeper
 integration-test: pretestinfra
 
 pretestinfra:
 	@echo Setting up Zookeeper and Kafka. Docker required.
 	@$(MAKE) start-containers
+
+.DEFAULT:
+	@$(MAKE) help
+
+## This help message
+.PHONY: help
+help:
+	@printf "\nUsage\n";
+
+	@awk '{ \
+			if ($$0 ~ /^.PHONY: [a-zA-Z\-\_0-9]+$$/) { \
+				helpCommand = substr($$0, index($$0, ":") + 2); \
+				if (helpMessage) { \
+					printf "\033[36m%-20s\033[0m %s\n", \
+						helpCommand, helpMessage; \
+					helpMessage = ""; \
+				} \
+			} else if ($$0 ~ /^[a-zA-Z\-\_0-9.]+:/) { \
+				helpCommand = substr($$0, 0, index($$0, ":")); \
+				if (helpMessage) { \
+					printf "\033[36m%-20s\033[0m %s\n", \
+						helpCommand, helpMessage; \
+					helpMessage = ""; \
+				} \
+			} else if ($$0 ~ /^##/) { \
+				if (helpMessage) { \
+					helpMessage = helpMessage"\n                     "substr($$0, 3); \
+				} else { \
+					helpMessage = substr($$0, 3); \
+				} \
+			} else { \
+				if (helpMessage) { \
+					print "\n                     "helpMessage"\n" \
+				} \
+				helpMessage = ""; \
+			} \
+		}' \
+		$(MAKEFILE_LIST)

--- a/skeleton/pipeline.mk
+++ b/skeleton/pipeline.mk
@@ -1,4 +1,4 @@
-################################################################################
+#
 #
 # March 2017
 # Copyright (c) 2017 by cisco Systems, Inc.
@@ -6,9 +6,10 @@
 #
 # Rudimentary build and test support
 #
-################################################################################
+#
 
 VERSION = $(shell git describe --always --long --dirty)
+COVER_PROFILE = -coverprofile=coverage.out
 
 PKG = $(shell go list)
 
@@ -43,15 +44,17 @@ integration-test:
 	@echo Starting Integration tests
 	$(GOTEST) -v -coverpkg=./... -tags=integration $(COVER_PROFILE) ./...
 
+## Unit tests
 .PHONY: test
 test:
 	$(GOTEST) -v $(COVER_PROFILE) ./...
 
+## Displays unit test coverage
 .PHONY: coverage
-COVER_PROFILE = -coverprofile=coverage.out
 coverage: test
 	$(GOTOOL) cover -html=coverage.out
 
+## Displays integration test coverage
 .PHONY: integration-coverage
 integration-coverage: integration-test
 	$(GOTOOL) cover -html=coverage.out


### PR DESCRIPTION
- Fixes #29
- Added ```make help```
- Any new target can be documented with two hashes above it `##`
- make help will present clean and crisp purpose for each target.
- .DEFAULT points to make help
- Removed binary from tree

#TODO

- .DEFAULT_GOAL is unchanged but should probably point to ```all```
  that would run through everything. Then introduce a make build

Example:

 reinaldopenno@REPENNO-M-9130  make help                                                                     

Usage
clean:                Removes containers, images, binaries and cache
integration-test:     Integration test with Kafka and Zookeper
help                  This help message
test                  Unit tests
coverage              Displays unit test coverage
integration-coverage  Displays integration test coverage

 reinaldopenno@REPENNO-M-9130   make unknown

Usage
clean:                Removes containers, images, binaries and cache
integration-test:     Integration test with Kafka and Zookeper
help                  This help message
test                  Unit tests
coverage              Displays unit test coverage
integration-coverage  Displays integration test coverage