### PR TITLE
Go Report Card

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,9 +7,11 @@ GOTOOL  = $(GOCMD) tool
 GOBASE := $(shell pwd)
 GOBIN  := $(GOBASE)/bin
 DOCKER := $(GOBASE)/tools/test
-
 # name of executable.
-BINARY = pipeline
+BINARY  = pipeline
+BINDIR  = bin
+
+.DEFAULT_GOAL := all
 
 include skeleton/pipeline.mk
 
@@ -27,16 +29,19 @@ start-containers: clean-containers
 	@echo "  >  Starting containers"
 	@cd $(DOCKER) && docker-compose up -d
 
-# Alias for integration-test
+## Alias for integration-test
 testall: integration-test
 
-
 ## Integration test with Kafka and Zookeper
-integration-test: pretestinfra
+integration-test: pre-integration
 
-pretestinfra:
+pre-integration:
 	@echo Setting up Zookeeper and Kafka. Docker required.
 	@$(MAKE) start-containers
+
+## Default target. Builds and executes unit tests
+.PHONY: all
+all: build test
 
 .DEFAULT:
 	@$(MAKE) help
@@ -44,7 +49,7 @@ pretestinfra:
 ## This help message
 .PHONY: help
 help:
-	@printf "\nUsage\n";
+	@printf "\nUsage:\n";
 
 	@awk '{ \
 			if ($$0 ~ /^.PHONY: [a-zA-Z\-\_0-9]+$$/) { \

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Go Report Card](https://goreportcard.com/badge/cisco-ie/pipeline-gnmi)](https://goreportcard.com/report/cisco-ie/pipeline-gnmi)
+
 # Pipeline with GNMI and improved Docker support
 
 This is an improved version of the open-source tool pipeline for telemetry consumption.

--- a/skeleton/pipeline.mk
+++ b/skeleton/pipeline.mk
@@ -1,7 +1,7 @@
 #
 #
 # March 2017
-# Copyright (c) 2017 by cisco Systems, Inc.
+# Copyright (c) 2017-2019 by cisco Systems, Inc.
 # All rights reserved.
 #
 # Rudimentary build and test support
@@ -23,17 +23,15 @@ LDFLAGS = -ldflags "-X  main.appVersion=v${VERSION}(bigmuddy)"
 
 SOURCEDIR = .
 SOURCES := $(shell find $(SOURCEDIR) -name '*.go' -o -name "*.proto" )
-# Cumbersome way of excluding vendor directory
-GO_BAR_VENDOR := $(shell go list ./... | egrep -v vendor/)
 
-.DEFAULT_GOAL: bin/$(BINARY)
-
-# Build binary in bin directory
-bin/$(BINARY): $(SOURCES)
-	@mkdir -p bin
-	go vet $(GO_BAR_VENDOR)
-	go fmt $(GO_BAR_VENDOR)
-	$(GOBUILD) $(LDFLAGS) -o bin/$(BINARY)
+## Build binary
+.PHONY: build
+build:
+	@echo "  >  Building pipeline"
+	@mkdir -p $(BINDIR)
+	go vet ./...
+	go fmt ./...
+	$(GOBUILD) $(LDFLAGS) -o $(BINDIR)/$(BINARY)
 
 .PHONY: generated-source
 generated-source:
@@ -44,7 +42,7 @@ integration-test:
 	@echo Starting Integration tests
 	$(GOTEST) -v -coverpkg=./... -tags=integration $(COVER_PROFILE) ./...
 
-## Unit tests
+## Run unit tests
 .PHONY: test
 test:
 	$(GOTEST) -v $(COVER_PROFILE) ./...


### PR DESCRIPTION
- Fixes #31
- Change binary target name to build
- default goal is all
- Vendor directory is ignored by default, no need to exclude files
   anymore