### PR TITLE
Build MacOS, Linux, and Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 The original pipeline README is included [here](README-PIPELINE.md) for reference.
 
 ## Usage
-pipeline-gnmi is written in Go and targets Go 1.11+.
+pipeline-gnmi is written in Go and targets Go 1.11+. Windows and MacOS/Darwin support is experimental.
 
 1) pipeline-gnmi binaries may be downloaded from [Releases](https://github.com/cisco-ie/pipeline-gnmi/releases)
 2) Built from source:

--- a/skeleton/pipeline.mk
+++ b/skeleton/pipeline.mk
@@ -24,14 +24,26 @@ LDFLAGS = -ldflags "-X  main.appVersion=v${VERSION}(bigmuddy)"
 SOURCEDIR = .
 SOURCES := $(shell find $(SOURCEDIR) -name '*.go' -o -name "*.proto" )
 
-## Build binary
+# Derived from https://vic.demuzere.be/articles/golang-makefile-crosscompile/
+PLATFORMS := linux/amd64 windows/amd64 darwin/amd64
+GOPLATFORMTEMP = $(subst /, ,$@)
+GOOS = $(word 1, $(GOPLATFORMTEMP))
+GOARCH = $(word 2, $(GOPLATFORMTEMP))
+
+.PHONY: $(PLATFORMS)
+$(PLATFORMS):
+	@echo "  >  Building for ${GOOS}/${GOARCH}"
+	GOOS=$(GOOS) GOARCH=$(GOARCH) $(GOBUILD) $(LDFLAGS) -o $(BINDIR)/$(BINARY)_$(GOOS)_$(GOARCH)
+
+## Build binaries
 .PHONY: build
-build:
-	@echo "  >  Building pipeline"
-	@mkdir -p $(BINDIR)
+build: hygiene $(PLATFORMS)
+
+## Run Go hygiene tooling like vet and fmt
+hygiene:
+	@echo "  >  Running Go hygiene tooling"
 	go vet -composites=false ./...
 	go fmt ./...
-	$(GOBUILD) $(LDFLAGS) -o $(BINDIR)/$(BINARY)
 
 .PHONY: generated-source
 generated-source:


### PR DESCRIPTION
`make build` now refers to `make hygiene`, `make darwin/amd64`, `make linux/amd64`, and `make windows/amd64`. The individual builds are controlled by the `PLATFORMS` variable - I could not determine how to effectively document them in `make help`.
Resolves #14 